### PR TITLE
Add launchfile and .yaml-files for storing robot-specific params

### DIFF
--- a/launch/differential_drive_yaml.launch
+++ b/launch/differential_drive_yaml.launch
@@ -1,0 +1,29 @@
+<launch>
+  <rosparam command="load"
+      file="$(find differential_drive)/launch/$(env ROBOT)_global.yaml">
+  </rosparam>
+
+  <node pkg="differential_drive" type="pid_velocity" name="lpid_velocity">
+    <remap from="wheel" to="lwheel"/>
+    <remap from="motor_cmd" to="lmotor_cmd"/>
+    <remap from="wheel_vtarget" to="lwheel_vtarget"/>
+    <remap from="wheel_vel" to="lwheel_vel"/>
+    <rosparam command="load"
+        file="$(find differential_drive)/launch/$(env ROBOT)_local.yaml">
+    </rosparam>
+  </node>
+  <node pkg="differential_drive" type="pid_velocity" name="rpid_velocity">
+    <remap from="wheel" to="rwheel"/>
+    <remap from="motor_cmd" to="rmotor_cmd"/>
+    <remap from="wheel_vtarget" to="rwheel_vtarget"/>
+    <remap from="wheel_vel" to="rwheel_vel"/>
+    <rosparam command="load"
+        file="$(find differential_drive)/launch/$(env ROBOT)_local.yaml">
+    </rosparam>
+  </node>
+
+  <node pkg="differential_drive" type="twist_to_motors.py"
+      name="twist_to_motors" output="screen">
+    <remap from="twist" to="cmd_vel"/>
+  </node>
+</launch>

--- a/launch/gopigo3_global.yaml
+++ b/launch/gopigo3_global.yaml
@@ -1,0 +1,2 @@
+ticks_meter: 1724
+base_width: 0.12

--- a/launch/gopigo3_local.yaml
+++ b/launch/gopigo3_local.yaml
@@ -1,0 +1,8 @@
+Kp: 180
+Ki: 0
+Kd: 0
+out_min: -255
+out_max: 255
+rate: 30
+timeout_ticks: 4
+rolling_pts: 5

--- a/launch/knex_global.yaml
+++ b/launch/knex_global.yaml
@@ -1,0 +1,2 @@
+ticks_meter: 70
+base_width: 0.245

--- a/launch/knex_local.yaml
+++ b/launch/knex_local.yaml
@@ -1,0 +1,8 @@
+Kp: 200
+Ki: 200
+Kd: 0
+out_min: -255
+out_max: 255
+rate: 30
+timeout_ticks: 4
+rolling_pts: 5


### PR DESCRIPTION
* Added a launchfile for launching a controller with basic functionality
('twist_to_motors', 'pid_velocity'). Robot-specific parameters are
provided via .yaml-files. Parameter files for the gopigo3 and knex robots
are provided with this commit. Obviously, more parameter files can be
added when using the controller with other robots. The proper parameter
files for a robot are chosen by defining the environment variable 'ROBOT'
before launching the script 'differential_drive_yaml.launch'.

* This method should enable the package user to conveniently choose and
switch between parameters for a specific robot.
Parameter files for different robots can be collected in the repository
as they are of general use.